### PR TITLE
.gitignore for rbenv, RVM .ruby-version file, referring to Ruby MRI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ deps
 *.o
 *.beam
 *.plt
+.*-*
 erl_crash.dump
 ebin
 rel/example_project


### PR DESCRIPTION
Hi, I am Jun.
I updated .gitignore for rbenv, RVM .ruby-version file, which is created by rbenv local X.Y.Z.
I referred MRI's .gitignore file.
https://github.com/ruby/ruby/blob/trunk/.gitignore

Thanks for ErRuby.
